### PR TITLE
docs(server-functions): clarify SSR guard

### DIFF
--- a/packages/qwik-city/src/runtime/src/server-functions.ts
+++ b/packages/qwik-city/src/runtime/src/server-functions.ts
@@ -88,7 +88,7 @@ export const routeActionQrl = ((
     });
 
     const submit = $((input: unknown | FormData | SubmitEvent = {}) => {
-      // only throw in true SSR (no mock context)
+      // only throw in true SSR when no window object is present (no mock context)
       if (isServer && typeof window === 'undefined') {
         throw new Error(`Actions can not be invoked within the server during SSR.
 Action.run() can only be called on the browser, for example when a user clicks a button, or submits a form.`);


### PR DESCRIPTION
## Summary
- clarify comment about when server action guard throws

## Testing
- `pnpm vitest packages/qwik-city` *(fails: Failed to load @builder.io/qwik/preloader)*

------
https://chatgpt.com/codex/tasks/task_e_6890e022db40832f94089e921d086963